### PR TITLE
disable-reward-splits

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -3556,7 +3556,7 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
     }
 
     // If reward percent is 100 then send all to reward address - *technium - added fork height check
-    if(hasPayment && payeerewardpercent == 100 && !fTestNet && pindexBest+1 < nForkOne || hasPayment && payeerewardpercent == 100 && fTestNet && pindexBest+1 > nTestnetForkOne){
+    if(hasPayment && payeerewardpercent == 100 && !fTestNet && pindexBest+1 < nForkOne || hasPayment && payeerewardpercent == 100 && fTestNet && pindexBest+1 < nTestnetForkOne){
         payments = txNew.vout.size() + 1;
         txNew.vout.resize(payments);
 
@@ -3571,7 +3571,7 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
     }
 
     // If reward percent more than 0 and lower than 100 then split reward - *technium- added fork height check
-    if(hasPayment && payeerewardpercent > 0 && payeerewardpercent < 100 && !fTestNet && pindexBest+1 < nForkOne || hasPayment && fTestNet && pindexBest+1 > nTestnetForkOne){
+    if(hasPayment && payeerewardpercent > 0 && payeerewardpercent < 100 && !fTestNet && pindexBest+1 < nForkOne || hasPayment && payeerewardpercent > 0 && payeerewardpercent < 100 && fTestNet && pindexBest+1 < nTestnetForkOne){
         payments = txNew.vout.size() + 2;
         txNew.vout.resize(payments);
 

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -3540,8 +3540,8 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
             }
         }
     }
-    // If reward percent is 0 then send all to masternode address
-    if(hasPayment && payeerewardpercent == 0){
+    // If reward percent is 0 then send all to masternode address *technium - added fork height check / enforce all to MN address
+    if(hasPayment && payeerewardpercent == 0 || hasPayment && !fTestNet && pindexBest+1 > nForkOne || hasPayment && fTestNet && pindexBest+1 > nTestnetForkOne){
         payments = txNew.vout.size() + 1;
         txNew.vout.resize(payments);
 
@@ -3555,8 +3555,8 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
         LogPrintf("Masternode payment to %s\n", address2.ToString().c_str());
     }
 
-    // If reward percent is 100 then send all to reward address
-    if(hasPayment && payeerewardpercent == 100){
+    // If reward percent is 100 then send all to reward address - *technium - added fork height check
+    if(hasPayment && payeerewardpercent == 100 && !fTestNet && pindexBest+1 < nForkOne || hasPayment && payeerewardpercent == 100 && fTestNet && pindexBest+1 > nTestnetForkOne){
         payments = txNew.vout.size() + 1;
         txNew.vout.resize(payments);
 
@@ -3570,8 +3570,8 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
         LogPrintf("Masternode payment to %s\n", address2.ToString().c_str());
     }
 
-    // If reward percent more than 0 and lower than 100 then split reward
-    if(hasPayment && payeerewardpercent > 0 && payeerewardpercent < 100){
+    // If reward percent more than 0 and lower than 100 then split reward - *technium- added fork height check
+    if(hasPayment && payeerewardpercent > 0 && payeerewardpercent < 100 && !fTestNet && pindexBest+1 < nForkOne || hasPayment && fTestNet && pindexBest+1 > nTestnetForkOne){
         payments = txNew.vout.size() + 2;
         txNew.vout.resize(payments);
 


### PR DESCRIPTION
Disables  the splitting of MN reward payments from 0-100% <external-address> to 0% only external address